### PR TITLE
Change hover colour in Quick Panel so it's distinguished from selected colour

### DIFF
--- a/Broceanic.sublime-theme
+++ b/Broceanic.sublime-theme
@@ -816,7 +816,7 @@
         "class": "quick_panel_row",
         "attributes": ["hover"],
         "layer0.texture": "",
-        "layer0.tint": [95, 179, 179]
+        "layer0.tint": [44, 79, 86]
     },
     {
         "class": "quick_panel_row",


### PR DESCRIPTION
Hi,

Great theme thanks - one thing that bugged me was bringing up the Quick Panel and if my mouse was near the top of the screen I am unable to distinguish which item I am selecting with the text filter/keyboard vs which item the mouse happens to be hovering over:

![screen shot 2015-07-24 at 14 39 30](https://cloud.githubusercontent.com/assets/760314/8875634/83864f58-3212-11e5-9037-828880bb4e5f.png)

Seemed to make sense to me to distinguish them so you can see what item is currently selected vs what is currently being hovered over:

![screen shot 2015-07-24 at 14 45 18](https://cloud.githubusercontent.com/assets/760314/8875652/abece894-3212-11e5-8632-c5baf3c532d8.png)

When you hover over items in the menu it just has a more subtle highlight:

![screen shot 2015-07-24 at 14 39 08](https://cloud.githubusercontent.com/assets/760314/8875666/c9f3fc42-3212-11e5-9aae-cf52cb25caa8.png)

If you hover over a selected item it isn't affected and stays bright.
