### PR TITLE
Visible scrollbars (pucks)

### DIFF
--- a/Broceanic.sublime-theme
+++ b/Broceanic.sublime-theme
@@ -816,7 +816,7 @@
         "class": "quick_panel_row",
         "attributes": ["hover"],
         "layer0.texture": "",
-        "layer0.tint": [95, 179, 179]
+        "layer0.tint": [44, 79, 86]
     },
     {
         "class": "quick_panel_row",

--- a/Broceanic.sublime-theme
+++ b/Broceanic.sublime-theme
@@ -305,7 +305,7 @@
     {
         "class": "puck_control",
         "layer0.texture": "",
-        "layer0.tint":[30,48,58],
+        "layer0.tint":[44,79,86],
         "layer0.opacity": 1,
         "layer0.inner_margin": [0,0],
         "content_margin": [6,0],
@@ -316,7 +316,7 @@
         "class": "puck_control",
         "attributes": ["horizontal"],
         "layer0.texture": "",
-        "layer0.tint":[30,48,58],
+        "layer0.tint":[44,79,86],
         "layer0.inner_margin": [0,0],
         "content_margin": [12,6],
         "blur": false


### PR DESCRIPTION
Having invisible scrollbars (pucks) looks minimal but gets in the way of usability - take NPM for instance - now that dependencies are flat you typically have dozens or hundreds of modules and scrolling that with the mouse wheel is a pain:

![screen shot 2016-02-17 at 17 22 03](https://cloud.githubusercontent.com/assets/760314/13118326/a703ad54-d59b-11e5-996b-35310cc22129.png)

Now you can see the pucks and don't have to spend a minute finger scrolling or guessing where the pucks are:

![screen shot 2016-02-17 at 17 21 33](https://cloud.githubusercontent.com/assets/760314/13118346/be995df6-d59b-11e5-8619-b1d07c2fde6d.png)
